### PR TITLE
(feat) add google site verify page (part of in-app chrome ext requirement)

### DIFF
--- a/public/googleb42f9b34759c2e52.html
+++ b/public/googleb42f9b34759c2e52.html
@@ -1,0 +1,1 @@
+google-site-verification: googleb42f9b34759c2e52.html


### PR DESCRIPTION
Once we are Google-verified, we can create a button to let users download the Chrome screenshare extension.
